### PR TITLE
Bot ID/URL verification

### DIFF
--- a/ff_bot/ff_bot.py
+++ b/ff_bot/ff_bot.py
@@ -33,7 +33,7 @@ class GroupMeBot(object):
 
         headers = {'content-type': 'application/json'}
 
-        if self.bot_id not in (1, "1", ''):
+        if self.bot_id not in (1, "1"):
             r = requests.post("https://api.groupme.com/v3/bots/post",
                               data=json.dumps(template), headers=headers)
             if r.status_code != 202:
@@ -58,7 +58,7 @@ class SlackBot(object):
 
         headers = {'content-type': 'application/json'}
 
-        if self.webhook_url not in (1, "1", ''):
+        if self.webhook_url not in (1, "1"):
             r = requests.post(self.webhook_url,
                               data=json.dumps(template), headers=headers)
 
@@ -84,10 +84,9 @@ class DiscordBot(object):
 
         headers = {'content-type': 'application/json'}
 
-        if self.webhook_url not in (1, "1", ''):
+        if self.webhook_url not in (1, "1"):
             r = requests.post(self.webhook_url,
                               data=json.dumps(template), headers=headers)
-
             if r.status_code != 204:
                 raise DiscordException('WEBHOOK_URL')
 

--- a/ff_bot/ff_bot.py
+++ b/ff_bot/ff_bot.py
@@ -254,6 +254,11 @@ def bot_main(function):
         discord_webhook_url = os.environ["DISCORD_WEBHOOK_URL"]
     except KeyError:
         discord_webhook_url = 1
+  
+    
+    if len(str(bot_id)) <= 1 and len(str(slack_webhook_url)) <= 1 and len(str(discord_webhook_url)) <= 1:
+        #Ensure that there's info for at least one messaging platform, use length of str in case of blank but non null env variable
+        raise Exception("No messaging platform info provided. Be sure one of BOT_ID, SLACK_WEBHOOK_URL, or DISCORD_WEBHOOK_URL env variables are set")
 
     league_id = os.environ["LEAGUE_ID"]
 

--- a/ff_bot/ff_bot.py
+++ b/ff_bot/ff_bot.py
@@ -253,11 +253,14 @@ def bot_main(function):
         discord_webhook_url = os.environ["DISCORD_WEBHOOK_URL"]
     except KeyError:
         discord_webhook_url = 1
-  
-    
-    if len(str(bot_id)) <= 1 and len(str(slack_webhook_url)) <= 1 and len(str(discord_webhook_url)) <= 1:
-        #Ensure that there's info for at least one messaging platform, use length of str in case of blank but non null env variable
-        raise Exception("No messaging platform info provided. Be sure one of BOT_ID, SLACK_WEBHOOK_URL, or DISCORD_WEBHOOK_URL env variables are set")
+ 
+    if (len(str(bot_id)) <= 1 and 
+        len(str(slack_webhook_url)) <= 1 and
+        len(str(discord_webhook_url)) <= 1):
+        #Ensure that there's info for at least one messaging platform,
+        #use length of str in case of blank but non null env variable
+        raise Exception("No messaging platform info provided. Be sure one of BOT_ID,\
+                        SLACK_WEBHOOK_URL, or DISCORD_WEBHOOK_URL env variables are set")
 
     league_id = os.environ["LEAGUE_ID"]
 

--- a/ff_bot/ff_bot.py
+++ b/ff_bot/ff_bot.py
@@ -253,8 +253,8 @@ def bot_main(function):
         discord_webhook_url = os.environ["DISCORD_WEBHOOK_URL"]
     except KeyError:
         discord_webhook_url = 1
- 
-    if (len(str(bot_id)) <= 1 and 
+
+    if (len(str(bot_id)) <= 1 and
         len(str(slack_webhook_url)) <= 1 and
         len(str(discord_webhook_url)) <= 1):
         #Ensure that there's info for at least one messaging platform,


### PR DESCRIPTION
I was accidentally setting WEBHOOK_URL as an env variable, which meant I wasn't setting DISCORD_WEBHOOK_URL, but the program ran fine, not acknowledging that there was no actual bot initialized. This checks the bot_id and webhook_urls after the try and except blocks that set them to 1 if the expected environment variables aren't present. It's possible, as it was in my testing, that you could have the env variables set but with an erroneous character, so I made the test a little more inclusive by casting the variables as strings and checking length. It just so happened the i set it to null, which was in the if statement about whether to try sending a message or not. So a null value of a set env variable would sneak through. Arguable these changes are redundant, but at least one I would deem necessary.