### PR TITLE
Added week parameter to functions, adjusted final_score to look at previous week

### DIFF
--- a/ff_bot/ff_bot.py
+++ b/ff_bot/ff_bot.py
@@ -288,7 +288,7 @@ def bot_main(function):
     else:
         league = League(league_id, year, espn_s2, swid)
 
-    test = True
+    test = False
     if test:
         print(get_matchups(league))
         print(get_scoreboard_short(league))

--- a/ff_bot/ff_bot.py
+++ b/ff_bot/ff_bot.py
@@ -108,9 +108,6 @@ def random_phrase():
     return [random.choice(phrases)]
 
 def get_scoreboard_short(league, week=None):
-    # if a week isn't passed set it to the current week
-    if not week:
-        week = league.current_week
     #Gets current week's scoreboard
     box_scores = league.box_scores(week=week)
     score = ['%s %.2f - %.2f %s' % (i.home_team.team_abbrev, i.home_score,
@@ -120,9 +117,6 @@ def get_scoreboard_short(league, week=None):
     return '\n'.join(text)
 
 def get_projected_scoreboard(league, week=None):
-    # if a week isn't passed set it to the current week
-    if not week:
-        week = league.current_week
     #Gets current week's scoreboard projections
     box_scores = league.box_scores(week=week)
     score = ['%s %.2f - %.2f %s' % (i.home_team.team_abbrev, get_projected_total(i.home_lineup),
@@ -142,9 +136,6 @@ def get_projected_total(lineup):
     return total_projected
 
 def get_matchups(league, week=None):
-    # if a week isn't passed set it to the current week
-    if not week:
-        week = league.current_week
     #Gets current week's Matchups
     matchups = league.box_scores(week=week)
 
@@ -155,9 +146,6 @@ def get_matchups(league, week=None):
     return '\n'.join(text)
 
 def get_close_scores(league, week=None):
-    # if a week isn't passed set it to the current week
-    if not week:
-        week = league.current_week
     #Gets current closest scores (15.999 points or closer)
     matchups = league.box_scores(week=week)
     score = []
@@ -174,7 +162,7 @@ def get_close_scores(league, week=None):
     return '\n'.join(text)
 
 def get_power_rankings(league, week=None):
-    # if a week isn't passed set it to the current week
+    # power rankings requires an integer value, so this grabs the current week for that
     if not week:
         week = league.current_week
     #Gets current week's power rankings
@@ -188,9 +176,6 @@ def get_power_rankings(league, week=None):
     return '\n'.join(text)
 
 def get_trophies(league, week=None):
-    # if a week isn't passed set it to the current week
-    if not week:
-        week = league.current_week
     #Gets trophies for highest score, lowest score, closest score, and biggest win
     matchups = league.box_scores(week=week)
     low_score = 9999

--- a/ff_bot/ff_bot.py
+++ b/ff_bot/ff_bot.py
@@ -288,7 +288,7 @@ def bot_main(function):
     else:
         league = League(league_id, year, espn_s2, swid)
 
-    test = False
+    test = True
     if test:
         print(get_matchups(league))
         print(get_scoreboard_short(league))
@@ -321,7 +321,7 @@ def bot_main(function):
         text = get_trophies(league)
     elif function=="get_final":
         # on Tuesday we need to get the scores of last week
-        week = league.get_current_week - 1
+        week = league.current_week - 1
         text = "Final " + get_scoreboard_short(league, week=week)
         text = text + "\n\n" + get_trophies(league)
     elif function=="init":

--- a/ff_bot/ff_bot.py
+++ b/ff_bot/ff_bot.py
@@ -107,18 +107,24 @@ def random_phrase():
                'Sigh']
     return [random.choice(phrases)]
 
-def get_scoreboard_short(league):
+def get_scoreboard_short(league, week=None):
+    # if a week isn't passed set it to the current week
+    if not week:
+        week = league.current_week
     #Gets current week's scoreboard
-    box_scores = league.box_scores()
+    box_scores = league.box_scores(week=week)
     score = ['%s %.2f - %.2f %s' % (i.home_team.team_abbrev, i.home_score,
              i.away_score, i.away_team.team_abbrev) for i in box_scores
              if i.away_team]
     text = ['Score Update'] + score
     return '\n'.join(text)
 
-def get_projected_scoreboard(league):
+def get_projected_scoreboard(league, week=None):
+    # if a week isn't passed set it to the current week
+    if not week:
+        week = league.current_week
     #Gets current week's scoreboard projections
-    box_scores = league.box_scores()
+    box_scores = league.box_scores(week=week)
     score = ['%s %.2f - %.2f %s' % (i.home_team.team_abbrev, get_projected_total(i.home_lineup),
                                     get_projected_total(i.away_lineup), i.away_team.team_abbrev) for i in box_scores
              if i.away_team]
@@ -135,9 +141,12 @@ def get_projected_total(lineup):
                 total_projected += i.projected_points
     return total_projected
 
-def get_matchups(league):
+def get_matchups(league, week=None):
+    # if a week isn't passed set it to the current week
+    if not week:
+        week = league.current_week
     #Gets current week's Matchups
-    matchups = league.box_scores()
+    matchups = league.box_scores(week=week)
 
     score = ['%s(%s-%s) vs %s(%s-%s)' % (i.home_team.team_name, i.home_team.wins, i.home_team.losses,
              i.away_team.team_name, i.away_team.wins, i.away_team.losses) for i in matchups
@@ -145,9 +154,12 @@ def get_matchups(league):
     text = ['Matchups'] + score + random_phrase()
     return '\n'.join(text)
 
-def get_close_scores(league):
+def get_close_scores(league, week=None):
+    # if a week isn't passed set it to the current week
+    if not week:
+        week = league.current_week
     #Gets current closest scores (15.999 points or closer)
-    matchups = league.box_scores()
+    matchups = league.box_scores(week=week)
     score = []
 
     for i in matchups:
@@ -161,20 +173,26 @@ def get_close_scores(league):
     text = ['Close Scores'] + score
     return '\n'.join(text)
 
-def get_power_rankings(league):
+def get_power_rankings(league, week=None):
+    # if a week isn't passed set it to the current week
+    if not week:
+        week = league.current_week
     #Gets current week's power rankings
     #Using 2 step dominance, as well as a combination of points scored and margin of victory.
     #It's weighted 80/15/5 respectively
-    power_rankings = league.power_rankings(week=-1)
+    power_rankings = league.power_rankings(week=week)
 
     score = ['%s - %s' % (i[0], i[1].team_name) for i in power_rankings
              if i]
     text = ['Power Rankings'] + score
     return '\n'.join(text)
 
-def get_trophies(league):
+def get_trophies(league, week=None):
+    # if a week isn't passed set it to the current week
+    if not week:
+        week = league.current_week
     #Gets trophies for highest score, lowest score, closest score, and biggest win
-    matchups = league.box_scores()
+    matchups = league.box_scores(week=week)
     low_score = 9999
     low_team_name = ''
     high_score = -1
@@ -278,6 +296,9 @@ def bot_main(function):
         print(get_close_scores(league))
         print(get_power_rankings(league))
         print(get_trophies(league))
+        # get last weeks scores
+        week = league.current_week - 1
+        print(get_scoreboard_short(league, week=week))
         function="get_final"
         bot.send_message("Testing")
         slack_bot.send_message("Testing")
@@ -299,7 +320,8 @@ def bot_main(function):
     elif function=="get_trophies":
         text = get_trophies(league)
     elif function=="get_final":
-        text = "Final " + get_scoreboard_short(league)
+        week = league.get_current_week - 1
+        text = "Final " + get_scoreboard_short(league, week=week)
         text = text + "\n\n" + get_trophies(league)
     elif function=="init":
         try:

--- a/ff_bot/ff_bot.py
+++ b/ff_bot/ff_bot.py
@@ -320,6 +320,7 @@ def bot_main(function):
     elif function=="get_trophies":
         text = get_trophies(league)
     elif function=="get_final":
+        # on Tuesday we need to get the scores of last week
         week = league.get_current_week - 1
         text = "Final " + get_scoreboard_short(league, week=week)
         text = text + "\n\n" + get_trophies(league)

--- a/ff_bot/ff_bot.py
+++ b/ff_bot/ff_bot.py
@@ -308,7 +308,7 @@ def bot_main(function):
         # on Tuesday we need to get the scores of last week
         week = league.current_week - 1
         text = "Final " + get_scoreboard_short(league, week=week)
-        text = text + "\n\n" + get_trophies(league)
+        text = text + "\n\n" + get_trophies(league, week=week)
     elif function=="init":
         try:
             text = os.environ["INIT_MSG"]


### PR DESCRIPTION
For #55 

The Tuesday scheduled task was running with an incorrect week variable and getting the scores for next week. I've refactored all the functions to take an optional week variable, and default to the current week from the league if none is passed. I've also adjusted the Tuesday final score function to pull the previous week.