### PR TITLE
Add variable for Daily Waiver Reporting

### DIFF
--- a/ff_bot/ff_bot.py
+++ b/ff_bot/ff_bot.py
@@ -6,17 +6,21 @@ from datetime import date
 from apscheduler.schedulers.blocking import BlockingScheduler
 from espn_api.football import League
 
+
 class GroupMeException(Exception):
     pass
+
 
 class SlackException(Exception):
     pass
 
+
 class DiscordException(Exception):
     pass
 
+
 class GroupMeBot(object):
-    #Creates GroupMe Bot to send messages
+    # Creates GroupMe Bot to send messages
     def __init__(self, bot_id):
         self.bot_id = bot_id
 
@@ -24,12 +28,12 @@ class GroupMeBot(object):
         return "GroupMeBot(%s)" % self.bot_id
 
     def send_message(self, text):
-        #Sends a message to the chatroom
+        # Sends a message to the chatroom
         template = {
-                    "bot_id": self.bot_id,
-                    "text": text,
-                    "attachments": []
-                    }
+            "bot_id": self.bot_id,
+            "text": text,
+            "attachments": []
+        }
 
         headers = {'content-type': 'application/json'}
 
@@ -41,8 +45,9 @@ class GroupMeBot(object):
 
             return r
 
+
 class SlackBot(object):
-    #Creates GroupMe Bot to send messages
+    # Creates GroupMe Bot to send messages
     def __init__(self, webhook_url):
         self.webhook_url = webhook_url
 
@@ -50,11 +55,11 @@ class SlackBot(object):
         return "Slack Webhook Url(%s)" % self.webhook_url
 
     def send_message(self, text):
-        #Sends a message to the chatroom
+        # Sends a message to the chatroom
         message = "```{0}```".format(text)
         template = {
-                    "text":message
-                    }
+            "text": message
+        }
 
         headers = {'content-type': 'application/json'}
 
@@ -67,8 +72,9 @@ class SlackBot(object):
 
             return r
 
+
 class DiscordBot(object):
-    #Creates Discord Bot to send messages
+    # Creates Discord Bot to send messages
     def __init__(self, webhook_url):
         self.webhook_url = webhook_url
 
@@ -76,11 +82,11 @@ class DiscordBot(object):
         return "Discord Webhook Url(%s)" % self.webhook_url
 
     def send_message(self, text):
-        #Sends a message to the chatroom
+        # Sends a message to the chatroom
         message = "```{0}```".format(text)
         template = {
-                    "content":message
-                    }
+            "content": message
+        }
 
         headers = {'content-type': 'application/json'}
 
@@ -92,6 +98,7 @@ class DiscordBot(object):
                 raise DiscordException('WEBHOOK_URL')
 
             return r
+
 
 def get_random_phrase():
     phrases = ['I\'m dead inside',
@@ -108,23 +115,26 @@ def get_random_phrase():
                'Sigh']
     return [random.choice(phrases)]
 
+
 def get_scoreboard_short(league, week=None):
-    #Gets current week's scoreboard
+    # Gets current week's scoreboard
     box_scores = league.box_scores(week=week)
     score = ['%s %.2f - %.2f %s' % (i.home_team.team_abbrev, i.home_score,
-             i.away_score, i.away_team.team_abbrev) for i in box_scores
+                                    i.away_score, i.away_team.team_abbrev) for i in box_scores
              if i.away_team]
     text = ['Score Update'] + score
     return '\n'.join(text)
 
+
 def get_projected_scoreboard(league, week=None):
-    #Gets current week's scoreboard projections
+    # Gets current week's scoreboard projections
     box_scores = league.box_scores(week=week)
     score = ['%s %.2f - %.2f %s' % (i.home_team.team_abbrev, get_projected_total(i.home_lineup),
-                        get_projected_total(i.away_lineup), i.away_team.team_abbrev) for i in box_scores
+                                    get_projected_total(i.away_lineup), i.away_team.team_abbrev) for i in box_scores
              if i.away_team]
     text = ['Approximate Projected Scores'] + score
     return '\n'.join(text)
+
 
 def get_standings(league, top_half_scoring, week=None):
     standings_txt = ''
@@ -132,8 +142,8 @@ def get_standings(league, top_half_scoring, week=None):
     standings = []
     if not top_half_scoring:
         standings = league.standings()
-        standings_txt = [f"{pos + 1}: {team.team_name} ({team.wins}-{team.losses})" for \
-            pos, team in enumerate(standings)]
+        standings_txt = [f"{pos + 1}: {team.team_name} ({team.wins}-{team.losses})" for
+                         pos, team in enumerate(standings)]
     else:
         top_half_totals = {t.team_name: 0 for t in teams}
         if not week:
@@ -146,17 +156,18 @@ def get_standings(league, top_half_scoring, week=None):
             standings.append((wins, t.losses, t.team_name))
 
         standings = sorted(standings, key=lambda tup: tup[0], reverse=True)
-        standings_txt = [f"{pos + 1}: {team_name} ({wins}-{losses}) (+{top_half_totals[team_name]})" for \
-            pos, (wins, losses, team_name) in enumerate(standings)]
+        standings_txt = [f"{pos + 1}: {team_name} ({wins}-{losses}) (+{top_half_totals[team_name]})" for
+                         pos, (wins, losses, team_name) in enumerate(standings)]
     text = ["Current Standings:"] + standings_txt
 
     return "\n".join(text)
+
 
 def top_half_wins(league, top_half_totals, week):
     box_scores = league.box_scores(week=week)
 
     scores = [(i.home_score, i.home_team.team_name) for i in box_scores] + \
-            [(i.away_score, i.away_team.team_name) for i in box_scores if i.away_team]
+        [(i.away_score, i.away_team.team_name) for i in box_scores if i.away_team]
 
     scores = sorted(scores, key=lambda tup: tup[0], reverse=True)
 
@@ -165,6 +176,7 @@ def top_half_wins(league, top_half_totals, week):
         top_half_totals[team_name] += 1
 
     return top_half_totals
+
 
 def get_projected_total(lineup):
     total_projected = 0
@@ -176,16 +188,18 @@ def get_projected_total(lineup):
                 total_projected += i.projected_points
     return total_projected
 
+
 def all_played(lineup):
     for i in lineup:
         if i.slot_position != 'BE' and i.slot_position != 'IR' and i.game_played < 100:
             return False
     return True
 
+
 def get_monitor(league):
     box_scores = league.box_scores()
     monitor = []
-    text=''
+    text = ''
     for i in box_scores:
         monitor += scan_roster(i.home_lineup, i.home_team)
         monitor += scan_roster(i.away_lineup, i.away_team)
@@ -196,13 +210,14 @@ def get_monitor(league):
         text = ['No Players to Monitor this week. Good Luck!']
     return '\n'.join(text)
 
+
 def scan_roster(lineup, team):
     count = 0
     players = []
     for i in lineup:
         if i.slot_position != 'BE' and i.slot_position != 'IR' and \
             i.injuryStatus != 'ACTIVE' and i.injuryStatus != 'NORMAL' \
-            and i.game_played == 0:
+                and i.game_played == 0:
 
             count += 1
             player = i.position + ' ' + i.name + ' - ' + i.injuryStatus.title().replace('_', ' ')
@@ -216,9 +231,10 @@ def scan_roster(lineup, team):
 
     if count > 0:
         s = '%s: \n%s \n' % (team.team_name, list[:-1])
-        report =  [s.lstrip()]
+        report = [s.lstrip()]
 
     return report
+
 
 def scan_inactives(lineup, team):
     count = 0
@@ -228,7 +244,8 @@ def scan_inactives(lineup, team):
             if i.injuryStatus == 'OUT' or i.injuryStatus == 'DOUBTFUL' or i.projected_points <= 0:
                 if i.game_played == 0:
                     count += 1
-                    players += ['%s %s - %s, %d pts' % (i.position, i.name, i.injuryStatus.title().replace('_', ' '), i.projected_points)]
+                    players += ['%s %s - %s, %d pts' %
+                                (i.position, i.name, i.injuryStatus.title().replace('_', ' '), i.projected_points)]
 
     inactive_list = ""
     inactives = ""
@@ -240,12 +257,13 @@ def scan_inactives(lineup, team):
 
     return inactives
 
+
 def get_matchups(league, random_phrase, week=None):
-    #Gets current week's Matchups
+    # Gets current week's Matchups
     matchups = league.box_scores(week=week)
 
     score = ['%s(%s-%s) vs %s(%s-%s)' % (i.home_team.team_name, i.home_team.wins, i.home_team.losses,
-             i.away_team.team_name, i.away_team.wins, i.away_team.losses) for i in matchups
+                                         i.away_team.team_name, i.away_team.wins, i.away_team.losses) for i in matchups
              if i.away_team]
 
     text = ['Matchups'] + score
@@ -253,49 +271,56 @@ def get_matchups(league, random_phrase, week=None):
         text = text + get_random_phrase()
     return '\n'.join(text)
 
+
 def get_close_scores(league, week=None):
-    #Gets current closest scores (15.999 points or closer)
+    # Gets current closest scores (15.999 points or closer)
     matchups = league.box_scores(week=week)
     score = []
 
     for i in matchups:
         if i.away_team:
             diffScore = i.away_score - i.home_score
-            if ( -16 < diffScore <= 0 and not all_played(i.away_lineup)) or (0 <= diffScore < 16 and not all_played(i.home_lineup)):
+            if (-16 < diffScore <= 0 and not all_played(i.away_lineup)) or (0 <= diffScore < 16 and not all_played(i.home_lineup)):
                 score += ['%s %.2f - %.2f %s' % (i.home_team.team_abbrev, i.home_score,
-                        i.away_score, i.away_team.team_abbrev)]
+                                                 i.away_score, i.away_team.team_abbrev)]
     if not score:
         return('')
     text = ['Close Scores'] + score
     return '\n'.join(text)
 
+
 def get_waiver_report(league, faab):
     activities = league.recent_activity(50)
-    report     = []
-    today      = date.today().strftime('%Y-%m-%d')
+    report = []
+    today = date.today().strftime('%Y-%m-%d')
 
     for activity in activities:
         actions = activity.actions
-        d2      = date.fromtimestamp(activity.date/1000).strftime('%Y-%m-%d')
-        if d2 == today: #only get waiver activites from today
-            if len(actions) == 1 and actions[0][1] == 'WAIVER ADDED': # player added, but not dropped
+        d2 = date.fromtimestamp(activity.date/1000).strftime('%Y-%m-%d')
+        if d2 == today:  # only get waiver activites from today
+            if len(actions) == 1 and actions[0][1] == 'WAIVER ADDED':  # player added, but not dropped
                 if faab:
-                    s = '%s \nADDED %s %s ($%s)\n' % (actions[0][0].team_name, actions[0][2].position, actions[0][2].name, actions[0][3])
+                    s = '%s \nADDED %s %s ($%s)\n' % (actions[0][0].team_name,
+                                                      actions[0][2].position, actions[0][2].name, actions[0][3])
                 else:
                     s = '%s \nADDED %s %s\n' % (actions[0][0].team_name, actions[0][2].position, actions[0][2].name)
                 report += [s.lstrip()]
             elif len(actions) > 1:
-                if actions[0][1] == 'WAIVER ADDED' or  actions[1][1] == 'WAIVER ADDED':
+                if actions[0][1] == 'WAIVER ADDED' or actions[1][1] == 'WAIVER ADDED':
                     if actions[0][1] == 'WAIVER ADDED':
                         if faab:
-                            s = '%s \nADDED %s %s ($%s)\nDROPPED %s %s\n' % (actions[0][0].team_name, actions[0][2].position, actions[0][2].name, actions[0][3], actions[1][2].position, actions[1][2].name)
+                            s = '%s \nADDED %s %s ($%s)\nDROPPED %s %s\n' % (
+                                actions[0][0].team_name, actions[0][2].position, actions[0][2].name, actions[0][3], actions[1][2].position, actions[1][2].name)
                         else:
-                            s = '%s \nADDED %s %s\nDROPPED %s %s\n' % (actions[0][0].team_name, actions[0][2].position, actions[0][2].name, actions[1][2].position, actions[1][2].name)
+                            s = '%s \nADDED %s %s\nDROPPED %s %s\n' % (
+                                actions[0][0].team_name, actions[0][2].position, actions[0][2].name, actions[1][2].position, actions[1][2].name)
                     else:
                         if faab:
-                            s = '%s \nADDED %s %s ($%s)\nDROPPED %s %s\n' % (actions[0][0].team_name, actions[1][2].position, actions[1][2].name, actions[1][3], actions[0][2].position, actions[0][2].name)
+                            s = '%s \nADDED %s %s ($%s)\nDROPPED %s %s\n' % (
+                                actions[0][0].team_name, actions[1][2].position, actions[1][2].name, actions[1][3], actions[0][2].position, actions[0][2].name)
                         else:
-                            s = '%s \nADDED %s %s\nDROPPED %s %s\n' % (actions[0][0].team_name, actions[1][2].position, actions[1][2].name, actions[0][2].position, actions[0][2].name)
+                            s = '%s \nADDED %s %s\nDROPPED %s %s\n' % (
+                                actions[0][0].team_name, actions[1][2].position, actions[1][2].name, actions[0][2].position, actions[0][2].name)
                     report += [s.lstrip()]
 
     report.reverse()
@@ -307,19 +332,21 @@ def get_waiver_report(league, faab):
 
     return '\n'.join(text)
 
+
 def get_power_rankings(league, week=None):
     # power rankings requires an integer value, so this grabs the current week for that
     if not week:
         week = league.current_week
-    #Gets current week's power rankings
-    #Using 2 step dominance, as well as a combination of points scored and margin of victory.
-    #It's weighted 80/15/5 respectively
+    # Gets current week's power rankings
+    # Using 2 step dominance, as well as a combination of points scored and margin of victory.
+    # It's weighted 80/15/5 respectively
     power_rankings = league.power_rankings(week=week)
 
     score = ['%s - %s' % (i[0], i[1].team_name) for i in power_rankings
              if i]
     text = ['Power Rankings'] + score
     return '\n'.join(text)
+
 
 def get_expected_win(league, week=None):
     win_percent = expected_win_percent(league, week=week)
@@ -332,56 +359,63 @@ def get_expected_win(league, week=None):
 
     return '\n'.join(text)
 
-def expected_win_percent(league, week):
-    #This script gets power rankings, given an already-connected league and a week to look at. Requires espn_api
 
-    #Get what week most recently passed
+def expected_win_percent(league, week):
+    # This script gets power rankings, given an already-connected league and a week to look at. Requires espn_api
+
+    # Get what week most recently passed
     lastWeek = league.current_week
 
     if week:
         lastWeek = week
 
-    #initialize dictionaries to stash the projected record/expected wins for each week, and to stash each team's score for each week
+    # initialize dictionaries to stash the projected record/expected wins for each week, and to stash each team's score for each week
     projRecDicts = {i: {x: None for x in league.teams} for i in range(lastWeek)}
     teamScoreDicts = {i: {x: None for x in league.teams} for i in range(lastWeek)}
 
-    #initialize the dictionary for the final power ranking
+    # initialize the dictionary for the final power ranking
     powerRankingDict = {x: 0. for x in league.teams}
 
-    for i in range(lastWeek): #for each week that has been played
-        weekNumber = i+1      #set the week
-        boxes = league.box_scores(weekNumber)	#pull box scores from that week
-        for box in boxes:							#for each boxscore
-            teamScoreDicts[i][box.home_team] = box.home_score	#plug the home team's score into the dict
-            teamScoreDicts[i][box.away_team] = box.away_score	#and the away team's
+    for i in range(lastWeek):  # for each week that has been played
+        weekNumber = i+1  # set the week
+        boxes = league.box_scores(weekNumber)  # pull box scores from that week
+        for box in boxes:  # for each boxscore
+            teamScoreDicts[i][box.home_team] = box.home_score  # plug the home team's score into the dict
+            teamScoreDicts[i][box.away_team] = box.away_score  # and the away team's
 
-        for team in teamScoreDicts[i].keys():		#for each team
+        for team in teamScoreDicts[i].keys():  # for each team
             wins = 0
             losses = 0
             ties = 0
             oppCount = len(list(teamScoreDicts[i].keys()))-1
-            for opp in teamScoreDicts[i].keys():		#for each potential opponent
-                if team==opp:							#skip yourself
+            for opp in teamScoreDicts[i].keys():  # for each potential opponent
+                if team == opp:  # skip yourself
                     continue
-                if teamScoreDicts[i][team] > teamScoreDicts[i][opp]:	#win case
+                if teamScoreDicts[i][team] > teamScoreDicts[i][opp]:  # win case
                     wins += 1
-                if teamScoreDicts[i][team] < teamScoreDicts[i][opp]:	#loss case
+                if teamScoreDicts[i][team] < teamScoreDicts[i][opp]:  # loss case
                     losses += 1
 
-            if wins + losses != oppCount:			#in case of an unlikely tie
+            if wins + losses != oppCount:  # in case of an unlikely tie
                 ties = oppCount - wins - losses
 
-            projRecDicts[i][team] = (float(wins) + (0.5*float(ties)))/float(oppCount) #store the team's projected record for that week
+            # store the team's projected record for that week
+            projRecDicts[i][team] = (float(wins) + (0.5*float(ties)))/float(oppCount)
 
-    for team in powerRankingDict.keys():			#for each team
-        powerRankingDict[team] = sum([projRecDicts[i][team] for i in range(lastWeek)])/float(lastWeek) #total up the expected wins from each week, divide by the number of weeks
+    for team in powerRankingDict.keys():  # for each team
+        # total up the expected wins from each week, divide by the number of weeks
+        powerRankingDict[team] = sum([projRecDicts[i][team] for i in range(lastWeek)])/float(lastWeek)
 
-    powerRankingDictSortedTemp = {k: v for k, v in sorted(powerRankingDict.items(), key=lambda item: item[1],reverse=True)} #sort for presentation purposes
-    powerRankingDictSorted = {x: ('{:.2f}'.format(powerRankingDictSortedTemp[x]*100)) for x in powerRankingDictSortedTemp.keys()}  #put into a prettier format
-    return [(powerRankingDictSorted[x],x) for x in powerRankingDictSorted.keys()]    #return in the format that the bot expects
+    powerRankingDictSortedTemp = {k: v for k, v in sorted(powerRankingDict.items(
+    ), key=lambda item: item[1], reverse=True)}  # sort for presentation purposes
+    powerRankingDictSorted = {x: ('{:.2f}'.format(
+        powerRankingDictSortedTemp[x]*100)) for x in powerRankingDictSortedTemp.keys()}  # put into a prettier format
+    # return in the format that the bot expects
+    return [(powerRankingDictSorted[x], x) for x in powerRankingDictSorted.keys()]
+
 
 def get_trophies(league, week=None):
-    #Gets trophies for highest score, lowest score, closest score, and biggest win
+    # Gets trophies for highest score, lowest score, closest score, and biggest win
     matchups = league.box_scores(week=week)
     low_score = 9999
     low_team_name = ''
@@ -408,7 +442,7 @@ def get_trophies(league, week=None):
             low_score = i.away_score
             low_team_name = i.away_team.team_name
         if i.away_score - i.home_score != 0 and \
-            abs(i.away_score - i.home_score) < closest_score:
+                abs(i.away_score - i.home_score) < closest_score:
             closest_score = abs(i.away_score - i.home_score)
             if i.away_score - i.home_score < 0:
                 close_winner = i.home_team.team_name
@@ -433,8 +467,10 @@ def get_trophies(league, week=None):
     text = ['Trophies of the week:'] + low_score_str + high_score_str + close_score_str + blowout_str
     return '\n'.join(text)
 
+
 def str_to_bool(check):
-  return check.lower() in ("yes", "true", "t", "1")
+    return check.lower() in ("yes", "true", "t", "1")
+
 
 def bot_main(function):
     try:
@@ -454,9 +490,9 @@ def bot_main(function):
 
     if (len(str(bot_id)) <= 1 and
         len(str(slack_webhook_url)) <= 1 and
-        len(str(discord_webhook_url)) <= 1):
-        #Ensure that there's info for at least one messaging platform,
-        #use length of str in case of blank but non null env variable
+            len(str(discord_webhook_url)) <= 1):
+        # Ensure that there's info for at least one messaging platform,
+        # use length of str in case of blank but non null env variable
         raise Exception("No messaging platform info provided. Be sure one of BOT_ID,\
                         SLACK_WEBHOOK_URL, or DISCORD_WEBHOOK_URL env variables are set")
 
@@ -465,16 +501,16 @@ def bot_main(function):
     try:
         year = int(os.environ["LEAGUE_YEAR"])
     except KeyError:
-        year=2021
+        year = 2021
 
     try:
         swid = os.environ["SWID"]
     except KeyError:
-        swid='{1}'
+        swid = '{1}'
 
-    if swid.find("{",0) == -1:
+    if swid.find("{", 0) == -1:
         swid = "{" + swid
-    if swid.find("}",-1) == -1:
+    if swid.find("}", -1) == -1:
         swid = swid + "}"
 
     try:
@@ -522,7 +558,7 @@ def bot_main(function):
         league = League(league_id=league_id, year=year, espn_s2=espn_s2, swid=swid)
 
     if test:
-        print(get_matchups(league,random_phrase))
+        print(get_matchups(league, random_phrase))
         print(get_scoreboard_short(league))
         print(get_projected_scoreboard(league))
         print(get_close_scores(league))
@@ -533,46 +569,46 @@ def bot_main(function):
         print(get_monitor(league))
         if waiver_report and swid != '{1}' and espn_s2 != '1':
             print(get_waiver_report(league, faab))
-        function="get_final"
+        function = "get_final"
         # bot.send_message("Testing")
         # slack_bot.send_message("Testing")
         # discord_bot.send_message("Testing")
 
     text = ''
-    if function=="get_matchups":
+    if function == "get_matchups":
         text = get_matchups(league, random_phrase)
         text = text + "\n\n" + get_projected_scoreboard(league)
-    elif monitor_report and function=="get_monitor" :
+    elif monitor_report and function == "get_monitor":
         text = get_monitor(league)
-    elif function=="get_scoreboard_short":
+    elif function == "get_scoreboard_short":
         text = get_scoreboard_short(league)
         text = text + "\n\n" + get_projected_scoreboard(league)
-    elif function=="get_projected_scoreboard":
+    elif function == "get_projected_scoreboard":
         text = get_projected_scoreboard(league)
-    elif function=="get_close_scores":
+    elif function == "get_close_scores":
         text = get_close_scores(league)
-    elif function=="get_power_rankings":
+    elif function == "get_power_rankings":
         text = get_power_rankings(league)
     # elif function=="get_expected_win":
     #     text = get_expected_win(league)
     # elif function=="get_waiver_report":
     #     text = get_waiver_report(league)
-    elif function=="get_trophies":
+    elif function == "get_trophies":
         text = get_trophies(league)
-    elif function=="get_standings":
+    elif function == "get_standings":
         text = get_standings(league, top_half_scoring)
         if waiver_report and swid != '{1}' and espn_s2 != '1':
             text += '\n\n' + get_waiver_report(league, faab)
-    elif function=="get_final":
+    elif function == "get_final":
         # on Tuesday we need to get the scores of last week
         week = league.current_week - 1
         text = "Final " + get_scoreboard_short(league, week=week)
         text = text + "\n\n" + get_trophies(league, week=week)
-    elif function=="init":
+    elif function == "init":
         try:
             text = os.environ["INIT_MSG"]
         except KeyError:
-            #do nothing here, empty init message
+            # do nothing here, empty init message
             pass
     else:
         text = "Something happened. HALP"
@@ -583,66 +619,77 @@ def bot_main(function):
         discord_bot.send_message(text)
 
     if test:
-        #print "get_final" function
+        # print "get_final" function
         print(text)
+
 
 if __name__ == '__main__':
     try:
         ff_start_date = os.environ["START_DATE"]
     except KeyError:
-        ff_start_date='2021-09-09'
+        ff_start_date = '2021-09-09'
 
     try:
         ff_end_date = os.environ["END_DATE"]
     except KeyError:
-        ff_end_date='2022-01-04'
+        ff_end_date = '2022-01-04'
 
     try:
         my_timezone = os.environ["TIMEZONE"]
     except KeyError:
-        my_timezone='America/New_York'
+        my_timezone = 'America/New_York'
 
-    game_timezone='America/New_York'
+    try:
+        waiver_freq = os.environ["WAIVER_FREQUENCY"]
+    except:
+        waiver_freq = 'WEEKLY'
+
+    game_timezone = 'America/New_York'
     bot_main("init")
     sched = BlockingScheduler(job_defaults={'misfire_grace_time': 15*60})
 
-    #close scores (within 15.99 points): monday evening at 6:30pm east coast time.
-    #power rankings:                     tuesday evening at 6:30pm local time.
-    #trophies:                           tuesday morning at 7:30am local time.
-    #standings:                          wednesday morning at 7:30am local time.
-    #waiver report:                      wednesday morning at 7:30am local time. (optional)
-    #matchups:                           thursday evening at 7:30pm east coast time.
-    #score update:                       friday, monday, and tuesday morning at 7:30am local time.
-    #player monitor report:              sunday morning at 7:30am local time.
-    #score update:                       sunday at 4pm, 8pm east coast time.
+    # close scores (within 15.99 points): monday evening at 6:30pm east coast time.
+    # power rankings:                     tuesday evening at 6:30pm local time.
+    # trophies:                           tuesday morning at 7:30am local time.
+    # standings:                          wednesday morning at 7:30am local time.
+    # waiver report:                      wednesday morning at 7:30am local time. (optional)
+    # matchups:                           thursday evening at 7:30pm east coast time.
+    # score update:                       friday, monday, and tuesday morning at 7:30am local time.
+    # player monitor report:              sunday morning at 7:30am local time.
+    # score update:                       sunday at 4pm, 8pm east coast time.
 
     sched.add_job(bot_main, 'cron', ['get_close_scores'], id='close_scores',
-        day_of_week='mon', hour=18, minute=30, start_date=ff_start_date, end_date=ff_end_date,
-        timezone=game_timezone, replace_existing=True)
+                  day_of_week='mon', hour=18, minute=30, start_date=ff_start_date, end_date=ff_end_date,
+                  timezone=game_timezone, replace_existing=True)
     sched.add_job(bot_main, 'cron', ['get_power_rankings'], id='power_rankings',
-        day_of_week='tue', hour=18, minute=30, start_date=ff_start_date, end_date=ff_end_date,
-        timezone=my_timezone, replace_existing=True)
+                  day_of_week='tue', hour=18, minute=30, start_date=ff_start_date, end_date=ff_end_date,
+                  timezone=my_timezone, replace_existing=True)
     sched.add_job(bot_main, 'cron', ['get_final'], id='final',
-        day_of_week='tue', hour=7, minute=30, start_date=ff_start_date, end_date=ff_end_date,
-        timezone=my_timezone, replace_existing=True)
-    sched.add_job(bot_main, 'cron', ['get_standings'], id='standings',
-        day_of_week='wed', hour=7, minute=30, start_date=ff_start_date, end_date=ff_end_date,
-        timezone=my_timezone, replace_existing=True)
+                  day_of_week='tue', hour=7, minute=30, start_date=ff_start_date, end_date=ff_end_date,
+                  timezone=my_timezone, replace_existing=True)
+    if waiver_freq == 'WEEKLY':
+        sched.add_job(bot_main, 'cron', ['get_standings'], id='standings',
+                      day_of_week='wed', hour=7, minute=30, start_date=ff_start_date, end_date=ff_end_date,
+                      timezone=my_timezone, replace_existing=True)
+    else:
+        sched.add_job(bot_main, 'cron', ['get_standings'], id='standings',
+                      day_of_week='mon, tue, wed, thu, fri, sat, sun', hour=12, minute=1, start_date=ff_start_date, end_date=ff_end_date,
+                      timezone=my_timezone, replace_existing=True)
     # sched.add_job(bot_main, 'cron', ['get_waiver_report'], id='waiver_report',
     #     day_of_week='wed', hour=7, minute=31, start_date=ff_start_date, end_date=ff_end_date,
     #     timezone=my_timezone, replace_existing=True)
     sched.add_job(bot_main, 'cron', ['get_matchups'], id='matchups',
-        day_of_week='thu', hour=19, minute=30, start_date=ff_start_date, end_date=ff_end_date,
-        timezone=game_timezone, replace_existing=True)
+                  day_of_week='thu', hour=19, minute=30, start_date=ff_start_date, end_date=ff_end_date,
+                  timezone=game_timezone, replace_existing=True)
     sched.add_job(bot_main, 'cron', ['get_scoreboard_short'], id='scoreboard1',
-        day_of_week='fri,mon', hour=7, minute=30, start_date=ff_start_date, end_date=ff_end_date,
-        timezone=my_timezone, replace_existing=True)
+                  day_of_week='fri,mon', hour=7, minute=30, start_date=ff_start_date, end_date=ff_end_date,
+                  timezone=my_timezone, replace_existing=True)
     sched.add_job(bot_main, 'cron', ['get_monitor'], id='monitor',
-        day_of_week='sun', hour=7, minute=30, start_date=ff_start_date, end_date=ff_end_date,
-        timezone=my_timezone, replace_existing=True)
+                  day_of_week='sun', hour=7, minute=30, start_date=ff_start_date, end_date=ff_end_date,
+                  timezone=my_timezone, replace_existing=True)
     sched.add_job(bot_main, 'cron', ['get_scoreboard_short'], id='scoreboard2',
-        day_of_week='sun', hour='16,20', start_date=ff_start_date, end_date=ff_end_date,
-        timezone=game_timezone, replace_existing=True)
+                  day_of_week='sun', hour='16,20', start_date=ff_start_date, end_date=ff_end_date,
+                  timezone=game_timezone, replace_existing=True)
 
     print("Ready!")
     sched.start()


### PR DESCRIPTION
Hey, not sure if this is something you had in the works already but I wanted to run it by you and get your thoughts. I saw you recently added the FAAB variable which is awesome, I had one request regarding it:

In my league, where we use free agent budget, all free agents are always on waiver. So each day, there could be waiver requests that go through. Our waivers also go through at noon, so i added the environment variable WAIVER_FREQUENCY that allows users to set to DAILY, otherwise it defaults to how you had it before.

Im not sure if you'd prefer a different way to accomplish this, or also allow the time of the standings/waiver reporting to be configured too, but just wanted to see what you thought of adding something like this.

Also: my prettier settings must have changed some of the lines so to make it easier the only changes I made are lines 642-645 and 670-677